### PR TITLE
Guard against metadata being nil when callback is called

### DIFF
--- a/src/gregor/core.clj
+++ b/src/gregor/core.clj
@@ -354,9 +354,10 @@
            (reify Callback
              (onCompletion [this metadata ex]
                (try
-                 (callback {:offset (.offset metadata)
-                            :partition (.partition metadata)
-                            :topic (.topic metadata)}
+                 (callback (when metadata
+                             {:offset (.offset metadata)
+                              :partition (.partition metadata)
+                              :topic (.topic metadata)})
                            ex)
                  (catch Exception _ nil)))))
     (.send producer record)))


### PR DESCRIPTION
When the `send-then` callback is called during an error case, it will be called with `nil` for the value of `metadata` (https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L917).

This PR adds a bit of defensive code to avoid a `NullPointerException` and make callbacks for sends which have gone wrong.